### PR TITLE
refactor: Position AVAST as STRIDE+ threat modeling extension

### DIFF
--- a/AVAST-Framework.md
+++ b/AVAST-Framework.md
@@ -2,17 +2,77 @@
 
 ## Executive Summary
 
-The AVAST Framework is a specialized threat modeling methodology designed specifically for AI-assisted software development. Unlike traditional security frameworks that treat all code equally, AVAST recognizes and addresses the unique vulnerability patterns introduced by Large Language Models (LLMs) in code generation.
+AVAST is a threat modeling framework designed as a STRIDE+ extension specifically for AI-assisted software development. While STRIDE provides excellent general threat categorization (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege), it's intentionally broad to cover all systems. Security practitioners have long used "STRIDE+" to append domain-specific threats they don't want to overlook.
+
+AVAST represents the natural evolution of STRIDE+ for the AI era. You should absolutely continue using STRIDE for comprehensive threat modeling, but append AVAST to ensure you're addressing the specific, predictable vulnerability patterns that AI consistently introduces into generated code.
 
 ## Table of Contents
-1. [Background and Motivation](#background-and-motivation)
-2. [Core Principles](#core-principles)
-3. [The AVAST Components](#the-avast-components)
-4. [Implementation Strategy](#implementation-strategy)
-5. [Threat Modeling Process](#threat-modeling-process)
-6. [Metrics and Measurement](#metrics-and-measurement)
-7. [Case Studies](#case-studies)
-8. [Advanced Topics](#advanced-topics)
+1. [AVAST as a Threat Modeling Framework](#avast-as-a-threat-modeling-framework)
+2. [Background and Motivation](#background-and-motivation)
+3. [Core Principles](#core-principles)
+4. [The AVAST Components](#the-avast-components)
+5. [Implementation Strategy](#implementation-strategy)
+6. [Threat Modeling Process](#threat-modeling-process)
+7. [Metrics and Measurement](#metrics-and-measurement)
+8. [Case Studies](#case-studies)
+9. [Advanced Topics](#advanced-topics)
+
+## AVAST as a Threat Modeling Framework
+
+### The Evolution from STRIDE to STRIDE+ to AVAST
+
+**STRIDE** (developed by Microsoft) is the industry standard for threat modeling:
+- **S**poofing identity
+- **T**ampering with data
+- **R**epudiation
+- **I**nformation disclosure
+- **D**enial of service
+- **E**levation of privilege
+
+**STRIDE+** emerged as practitioners needed domain-specific extensions:
+- STRIDE + Cloud (adds multi-tenancy, shared responsibility)
+- STRIDE + IoT (adds physical access, firmware updates)
+- STRIDE + Mobile (adds device loss, app store threats)
+
+**AVAST** is STRIDE+ for AI-generated code:
+- **A**uthentication flaws (maps to Spoofing)
+- **V**alidation gaps (maps to Tampering/Information Disclosure)
+- **A**uditing deficiencies (maps to Repudiation)
+- **S**ecrets exposure (maps to Information Disclosure)
+- **T**rust boundary violations (maps to Elevation of Privilege)
+
+### Why AVAST Complements STRIDE
+
+STRIDE asks: "What can go wrong with this system?"
+AVAST asks: "What will AI get wrong when building this system?"
+
+Example threat modeling session:
+1. Apply STRIDE to identify general threats
+2. Apply AVAST to identify AI-specific vulnerabilities
+3. Combine findings for comprehensive coverage
+
+### Using STRIDE + AVAST Together
+
+```yaml
+threat_model:
+  component: User Authentication Service
+
+  stride_threats:
+    spoofing:
+      - Credential theft
+      - Session hijacking
+    tampering:
+      - Password modification
+      - Token manipulation
+
+  avast_threats:
+    authentication:
+      - AI will likely implement MD5 hashing
+      - AI won't implement rate limiting
+      - AI will store passwords in logs
+    validation:
+      - AI will concatenate SQL queries
+      - AI won't sanitize inputs
 
 ## Background and Motivation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing to AVAST Framework
 
-First off, thank you for considering contributing to AVAST! It's people like you that make AVAST such a great tool for securing AI-generated code.
+First off, thank you for considering contributing to AVAST! It's people like you that make AVAST such a great threat modeling extension for securing AI-generated code.
+
+## About AVAST
+
+AVAST is a STRIDE+ extension - a threat modeling framework that complements STRIDE by adding AI-specific vulnerability categories. Your contributions help security practitioners worldwide better threat model AI-assisted development.
 
 ## Table of Contents
 - [Code of Conduct](#code-of-conduct)
@@ -41,6 +45,7 @@ When you discover a new vulnerability pattern in AI-generated code:
 
 **AI Tool:** GitHub Copilot v1.x
 **AVAST Category:** Validation
+**STRIDE Category:** Tampering/Information Disclosure
 
 **Prompt Used:**
 "Create a function to search users by name"
@@ -60,6 +65,9 @@ function searchUsers(name) {
 ```
 
 **Impact:** SQL Injection vulnerability
+
+**Threat Model Addition:**
+This pattern should be added to AVAST validation checks when threat modeling database interactions in AI-generated code.
 ```
 
 ### 💡 Suggesting Enhancements

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # 🚢 AVAST Framework
+> **A Threat Modeling Framework for AI-Generated Code (STRIDE+ for AI)**
+
 > **A**uthentication | **V**alidation | **A**uditing | **S**ecrets | **T**rust
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Security Framework](https://img.shields.io/badge/Security-Framework-orange)](https://github.com/CEA-Brad/avast-toolkit)
-[![AI Development](https://img.shields.io/badge/AI-Development-blue)](https://github.com/CEA-Brad/avast-toolkit)
+[![Threat Modeling](https://img.shields.io/badge/Threat%20Modeling-STRIDE%2B-orange)](https://github.com/CEA-Brad/avast-toolkit)
+[![AI Security](https://img.shields.io/badge/AI-Security-blue)](https://github.com/CEA-Brad/avast-toolkit)
 
-## 🎯 The Problem
+## 🎯 What is AVAST?
+
+AVAST is a threat modeling framework that extends STRIDE specifically for AI-generated code. If you're familiar with STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege), you know it's excellent but intentionally general. Security practitioners have long used "STRIDE+" to add domain-specific concerns:
+
+- **STRIDE + Cloud** for cloud-specific threats
+- **STRIDE + IoT** for embedded systems
+- **STRIDE + Mobile** for mobile applications
+- **STRIDE + AVAST** for AI-generated code ✨
+
+## 📊 The Problem
 
 AI-generated code is creating a security crisis:
 - **45%** of AI-generated code fails basic security tests
@@ -14,28 +25,51 @@ AI-generated code is creating a security crisis:
 
 Despite this, **83% of organizations** use AI to generate production code.
 
-AVAST is a specialized threat modeling framework designed specifically for AI-assisted development, providing a structured approach to identify and mitigate vulnerabilities before they reach production.
+AVAST provides the specific threat categories that AI consistently gets wrong, allowing you to maintain comprehensive STRIDE coverage while ensuring AI-specific vulnerabilities don't slip through.
 
-## 🌟 Why AVAST?
+## 🌟 Why Use STRIDE + AVAST?
 
-Traditional security tools weren't designed for AI-generated code. AVAST fills this gap by:
+When threat modeling AI-assisted development:
 
-✅ **Proactive Security**: Catch vulnerabilities before AI generates them
+1. **Start with STRIDE** for comprehensive threat coverage
+2. **Add AVAST** to catch what AI specifically gets wrong
+3. **Get complete coverage** without redundancy
+
+Benefits:
+✅ **Proactive Security**: Catch AI-specific vulnerabilities during threat modeling
 ✅ **Context-Aware**: Provides the security context AI models lack
 ✅ **Measurable Impact**: 67% reduction in production vulnerabilities
-✅ **Developer-Friendly**: Integrates seamlessly with existing AI coding tools
+✅ **Industry Standard**: Builds on STRIDE, not replacing it
 
-## 📊 Framework Overview
+## 📊 The AVAST Components
 
-AVAST focuses on the five most critical vulnerability categories in AI-generated code:
+AVAST extends your STRIDE threat model with five AI-specific vulnerability categories:
 
-| Component | Description | Common AI Failures |
-|-----------|-------------|-------------------|
-| **Authentication** | Identity verification and session management | Hardcoded credentials, weak session handling |
-| **Validation** | Input sanitization and data validation | SQL injection, XSS vulnerabilities |
-| **Auditing** | Logging and monitoring | Sensitive data exposure, insufficient logging |
-| **Secrets** | Credential and key management | Secrets in code, plaintext storage |
-| **Trust** | Boundary validation and authorization | Missing authorization, privilege escalation |
+| AVAST Component | STRIDE Mapping | Description | Common AI Failures |
+|-----------------|----------------|-------------|-------------------|
+| **Authentication** | Spoofing | Identity verification and session management | Hardcoded credentials, weak session handling |
+| **Validation** | Tampering, Info Disclosure | Input sanitization and data validation | SQL injection, XSS vulnerabilities |
+| **Auditing** | Repudiation | Logging and monitoring | Sensitive data exposure, insufficient logging |
+| **Secrets** | Information Disclosure | Credential and key management | Secrets in code, plaintext storage |
+| **Trust** | Elevation of Privilege | Boundary validation and authorization | Missing authorization, privilege escalation |
+
+### How to Use STRIDE + AVAST
+
+```yaml
+# Traditional STRIDE threat model
+stride_analysis:
+  spoofing: [Check authentication mechanisms]
+  tampering: [Verify data integrity]
+  repudiation: [Ensure audit trails]
+
+# Add AVAST for AI-specific threats
+avast_analysis:
+  authentication: [AI won't implement rate limiting]
+  validation: [AI will concatenate SQL queries]
+  auditing: [AI will log passwords]
+  secrets: [AI will hardcode API keys]
+  trust: [AI will trust client-side validation]
+```
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
- Clarify AVAST as a threat modeling framework that extends STRIDE
- Explain STRIDE+ concept and how AVAST fits into this pattern
- Add mapping between AVAST components and STRIDE categories
- Update documentation to emphasize complementary relationship with STRIDE
- Show how to use STRIDE + AVAST together for comprehensive threat modeling

AVAST doesn't replace STRIDE - it extends it with AI-specific threat categories that practitioners need to consider when threat modeling AI-generated code.